### PR TITLE
Fix authentication with Ueberauth

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -50,7 +50,7 @@ config :phoenix, :json_library, Jason
 
 config :ueberauth, Ueberauth,
   providers: [
-    google: {Ueberauth.Strategy.Google, [default_score: "email profile"]}
+    google: {Ueberauth.Strategy.Google, [default_scope: "email profile"]}
   ]
 
 config :tailwind,

--- a/lib/quizzez_web/controllers/auth_controller.ex
+++ b/lib/quizzez_web/controllers/auth_controller.ex
@@ -7,11 +7,11 @@ defmodule QuizzezWeb.AuthController do
   plug(QuizzezWeb.Plugs.RedirectIfAuthenticated when action not in ~w[sign_out]a)
   plug Ueberauth
 
-  def callback(%{assigns: %{ueberauth_auth: %{info: user_info}}} = conn, %{"provider" => "google"}) do
+  def callback(%{assigns: %{ueberauth_auth: %{info: user_info}}} = conn, %{"provider" => provider}) do
     user_params = %{
       email: user_info.email,
       name: user_info.name || "Anonymous",
-      provider: "google"
+      provider: provider || "unknown"
     }
 
     changeset = User.changeset(%User{}, user_params)


### PR DESCRIPTION
There was a typo in the config of Ueberauth causing Google not providing the name of a user. 
This will fix this by... fix that typo 😄 