### PR TITLE
Add user menu item in dropdown

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,26 +1,7 @@
-// We import the CSS which is extracted to its own file by esbuild.
-// Remove this line if you add a your own CSS build pipeline (e.g postcss).
 import "../css/app.css";
-
-// If you want to use Phoenix channels, run `mix help phx.gen.channel`
-// to get started and then uncomment the line below.
-// import "./user_socket.js"
-
-// You can include dependencies in two ways.
-//
-// The simplest option is to put them in assets/vendor and
-// import them using relative paths:
-//
-//     import "./vendor/some-package.js"
-//
-// Alternatively, you can `npm install some-package` and import
-// them using a path starting with the package name:
-//
-//     import "some-package"
-//
-
-// Include phoenix_html to handle method=PUT/DELETE in forms and buttons.
 import "phoenix_html";
+import { handleMenuClick } from "./utils/user-menu";
+
 // Establish Phoenix Socket and LiveView configuration.
 import { Socket } from "phoenix";
 import { LiveSocket } from "phoenix_live_view";
@@ -41,8 +22,5 @@ window.addEventListener("phx:page-loading-stop", (info) => topbar.hide());
 // connect if there are any LiveViews on the page
 liveSocket.connect();
 
-// expose liveSocket on window for web console debug logs and latency simulation:
-// >> liveSocket.enableDebug()
-// >> liveSocket.enableLatencySim(1000)  // enabled for duration of browser session
-// >> liveSocket.disableLatencySim()
 window.liveSocket = liveSocket;
+handleMenuClick();

--- a/assets/js/utils/user-menu.js
+++ b/assets/js/utils/user-menu.js
@@ -1,0 +1,32 @@
+const userMenuItem = document.querySelector("#user-menu");
+const userMenuDropdown = document.querySelector("#user-menu__dropdown");
+
+export function handleMenuClick() {
+  if (!userMenuItem && !userMenuDropdown) return;
+
+  userMenuItem.addEventListener("click", () => {
+    showDropdown();
+  });
+}
+
+function showDropdown() {
+  userMenuDropdown.classList.toggle("invisible");
+
+  handleOutsideClick();
+}
+
+function handleOutsideClick() {
+  if (userMenuDropdown.classList.contains("invisible")) {
+    return;
+  }
+
+  document.addEventListener("click", onOutsideClick);
+
+  function onOutsideClick(event) {
+    if (userMenuItem.contains(event.target)) return;
+    if (userMenuDropdown.contains(event.target)) return;
+
+    userMenuDropdown.classList.add("invisible");
+    document.removeEventListener("click", handleOutsideClick);
+  }
+}

--- a/assets/static/svg/icons/chevron-down.svg
+++ b/assets/static/svg/icons/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+</svg>

--- a/assets/static/svg/icons/user.svg
+++ b/assets/static/svg/icons/user.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" width="20">
+  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+</svg>

--- a/lib/quizzez_web/templates/layout/header.html.heex
+++ b/lib/quizzez_web/templates/layout/header.html.heex
@@ -7,11 +7,26 @@
           <span class="header-logo__small">ez</span>
         </a>
       </div>
-      <%= if QuizzezWeb.Authentication.logged_in?(@conn) do %>
+      <%= if Authentication.logged_in?(@conn) do %>
         <ul class="header-nav__items">
           <li><%= link "Categories", to: Routes.category_path(@conn, :index) %></li>
-          <li><%= link "Profile", to: Routes.profile_path(@conn, :show, QuizzezWeb.Authentication.get_current_user(@conn).id) %></li>
-          <li><%= link "Logout", to: Routes.session_path(@conn, :delete), method: :delete %></li>
+          <li>
+            <div class="flex items-center gap-1 relative cursor-pointer">
+
+              <div id="user-menu" class="flex flex-row items-center gap-1">
+                <i class="max-w-[20px] inline-block"><%= SVGHelpers.inline_svg("icons/user") %></i>
+                <span><%= user_name(@conn) %></span>
+                <i class="max-w-[12px] inline-block"><%= SVGHelpers.inline_svg("icons/chevron-down") %></i>
+              </div>
+
+              <div id="user-menu__dropdown" class="invisible absolute right-0 translate-y-[76px] bg-white p-2 rounded-xl border border-solid shadow-sm transition min-w-[180px] flex flex-col z-10">
+                <%= link "Profile", to: Routes.profile_path(@conn, :show, QuizzezWeb.Authentication.get_current_user(@conn).id), class: "hover:bg-gray-50 py-2 px-1" %>
+                <%= link "Logout", to: Routes.session_path(@conn, :delete), method: :delete, class: "hover:bg-gray-50 py-2 px-1" %>
+              </div>
+
+            </div>
+          </li>
+
         </ul>
         <% else %>
         <ul class="header-nav__items">

--- a/lib/quizzez_web/views/layout_view.ex
+++ b/lib/quizzez_web/views/layout_view.ex
@@ -2,8 +2,16 @@ defmodule QuizzezWeb.LayoutView do
   use QuizzezWeb, :view
 
   alias QuizzezWeb.SVGHelpers
+  alias QuizzezWeb.Authentication
+  alias Quizzez.Accounts.User
 
   # Phoenix LiveDashboard is available only in development by default,
   # so we instruct Elixir to not warn if the dashboard route is missing.
   @compile {:no_warn_undefined, {Routes, :live_dashboard_path, 2}}
+
+  def user_name(conn) do
+    %User{name: name} = Authentication.get_current_user(conn)
+
+    name
+  end
 end


### PR DESCRIPTION
This change will add menu items for logged in user (for now just link to profile and log out link) to a dropdown instead of rendering them directly in the header.

![bild](https://user-images.githubusercontent.com/44543626/153691625-87f28fdd-7afe-4aa1-b288-f4f45dd3fa15.png)
