### PR TITLE
Add floating dropdown with actions for quiz

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,8 +1,7 @@
 import "../css/app.css";
 import "phoenix_html";
 import { handleMenuClick } from "./utils/user-menu";
-
-// Establish Phoenix Socket and LiveView configuration.
+import { handleQuizDetailsClick } from "./utils/quiz-details-menu";
 import { Socket } from "phoenix";
 import { LiveSocket } from "phoenix_live_view";
 import topbar from "../vendor/topbar";
@@ -23,4 +22,8 @@ window.addEventListener("phx:page-loading-stop", (info) => topbar.hide());
 liveSocket.connect();
 
 window.liveSocket = liveSocket;
-handleMenuClick();
+
+window.addEventListener("DOMContentLoaded", () => {
+  handleMenuClick();
+  handleQuizDetailsClick();
+});

--- a/assets/js/utils/quiz-details-menu.js
+++ b/assets/js/utils/quiz-details-menu.js
@@ -1,0 +1,31 @@
+export function handleQuizDetailsClick() {
+  const quizDetailButtons = document.querySelectorAll(".quiz-details__btn");
+
+  if (!quizDetailButtons) return;
+
+  quizDetailButtons.forEach((button) => {
+    const userMenuDropdown = button.nextElementSibling;
+
+    button.addEventListener("click", (event) =>
+      showDropdown(event.target, userMenuDropdown)
+    );
+  });
+}
+
+function showDropdown(btnElement, dropDownElement) {
+  dropDownElement.classList.toggle("invisible");
+
+  handleOutsideClick(btnElement, dropDownElement);
+}
+
+function handleOutsideClick(menuElement, dropDownElement) {
+  document.addEventListener("click", onOutsideClick);
+
+  function onOutsideClick(event) {
+    if (menuElement.contains(event.target)) return;
+    if (dropDownElement.contains(event.target)) return;
+
+    dropDownElement.classList.add("invisible");
+    document.removeEventListener("click", handleOutsideClick);
+  }
+}

--- a/lib/quizzez_web/views/components/quiz_detail_card.ex
+++ b/lib/quizzez_web/views/components/quiz_detail_card.ex
@@ -3,6 +3,7 @@ defmodule QuizzezWeb.Components.QuizDetailCard do
   A card component to be used to show details about a Quiz
   """
   use Phoenix.Component
+  import Phoenix.HTML.Link
   alias QuizzezWeb.Router.Helpers, as: Routes
 
   def card(assigns) do
@@ -17,9 +18,11 @@ defmodule QuizzezWeb.Components.QuizDetailCard do
 
       <%= if @can_modify do %>
         <aside class="absolute -top-3 -right-3 border border-solid border-gray-300 rounded-full bg-white shadow-sm cursor-pointer hover:bg-gray-300">
-          <i class="">
-            <QuizzezWeb.Components.Icons.more_icon />
-          </i>
+          <i class="quiz-details__btn"><QuizzezWeb.Components.Icons.more_icon /></i>
+          <div class="quiz-details__menu invisible absolute right-6 lg:translate-y-[-6px] bg-white p-2 rounded-xl border border-solid shadow-sm transition min-w-[180px] flex flex-col z-10">
+            <%= link "Edit", to: "#", class: "hover:bg-gray-50 py-2 px-1" %>
+            <%= link "Delete", to: "#", class: "hover:bg-gray-50 py-2 px-1" %>
+          </div>
         </aside>
       <% end %>
 


### PR DESCRIPTION
This change will add logic to open dropdown menu with links to edit and delete a quiz when pressing the "more" button on `quiz_detail_card` 

![bild](https://user-images.githubusercontent.com/44543626/153707297-6414b13a-2a08-4f08-b475-fc8db5652a8b.png)
